### PR TITLE
removing src/test/resources from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+
+#empty folder
+src/test/resources

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,7 @@ yarn-error.log
 Thumbs.db
 
 #empty folder
-src/test/resources
+*/Project0/src/test/resources
+*/Project1/src/test/resources
+*/Project2/src/test/resources
+*/Project3/src/test/resources


### PR DESCRIPTION
I think src/test/resources should be in .gitignore.